### PR TITLE
Added a webpack build server config to make VS code development easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,3 +384,6 @@ ASALocalRun/
 # MSBuild Binary and Structured Log
 *.binlog
 
+dist/main.js
+package-lock.json
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -506,8 +506,9 @@
 	<script type="text/javascript" src="scripts/components/controls.component.js"></script>
 	<script type="text/javascript" src="scripts/components/settings.component.js"></script>
 	
-	<!-- The App -->
-	<script type="text/javascript" src="scripts/app.js"></script>
+    <!-- The App -->
+    <!-- app.js now being injected by webpack Dev server -->
+	<!-- <script type="text/javascript" src="scripts/app.js"></script> -->
 
 	<script type="text/javascript">
 		window['moment-range'].extendMoment(moment);

--- a/package.json
+++ b/package.json
@@ -1,11 +1,26 @@
 {
 	"version": "1.0.0",
 	"name": "ASP.NET",
+	"scripts": {
+		"build": "webpack --config webpack.config.dev.js",
+		"dev": "webpack-dev-server --config webpack.config.dev.js"
+	},
 	"private": true,
-	"devDependencies": {},
+	"devDependencies": {
+		"css-loader": "^2.1.0",
+		"html-webpack-plugin": "^3.2.0",
+		"vue-loader": "^15.5.1",
+		"vue-style-loader": "^4.1.2",
+		"vue-template-compiler": "^2.5.21",
+		"webpack": "^4.28.1",
+		"webpack-cli": "^3.2.1",
+		"webpack-dev-server": "^3.1.14"
+	},
 	"dependencies": {
 		"lodash": "^4.17.4",
 		"moment": "^2.20.1",
-		"moment-range": "^3.1.0"
+		"moment-range": "^3.1.0",
+		"vue": "^2.5.21",
+		"vue-router": "^3.0.2"
 	}
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,0 +1,41 @@
+'use strict'
+const webpack = require('webpack')
+const { VueLoaderPlugin } = require('vue-loader')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+module.exports = {
+  mode: 'development',
+  
+  entry: [
+    './scripts/app.js'
+  ],
+  devServer: {
+    hot: true,
+    watchOptions: {
+      poll: true
+    }
+  },
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        use: 'vue-loader'
+      },
+      {
+        test: /\.css$/,
+        use: [
+          'vue-style-loader',
+          'css-loader'
+        ]
+      }
+    ]
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new VueLoaderPlugin(),
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      template: 'index.html',
+      inject: true
+    })
+  ]
+}


### PR DESCRIPTION
Youll notice that the app.js is now commented in the index.html. I am not sure if the production build would need that still. So we might hold off on merging this in until then.

Run "npm install" to pull in all the new webpack dependencies
To Test this you can run "npm run dev" in the root project folder and then open localhost:8080